### PR TITLE
[FIX] base: fix "Original Bill" when file is image

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -178,8 +178,9 @@ class IrActionsReport(models.Model):
         if attachment.mimetype.startswith('image'):
             stream = io.BytesIO(base64.b64decode(attachment.datas))
             img = Image.open(stream)
-            img.convert("RGB").save(stream, format="pdf")
-            return stream
+            output_stream = io.BytesIO()
+            img.convert("RGB").save(output_stream, format="pdf")
+            return output_stream
         return io.BytesIO(base64.decodestring(attachment.datas))
 
     def retrieve_attachment(self, record):


### PR DESCRIPTION
1. Create an invoice and upload a picture file as the only attachment
2. Try to print "origin bill" for the invoice (From the invoice tree
view select one and click print > origin bill )

An error will raise "PIL.PdfParser.PdfFormatError: trailer end not found".
Fixing by using another BytesIO object as the output.

opw-2244625

closes odoo/odoo#50313

Signed-off-by: Nicolas Martinelli (nim) <nim@odoo.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
